### PR TITLE
ci: Update Luacheck Action to v0.2.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,5 @@ jobs:
           args: --check .
       
       - name: Lint
-        uses: judaew/luacheck-action@v0.2.1
-        with:
-          targets: "."
+        uses: judaew/luacheck-action@v0.2.2
 


### PR DESCRIPTION
See https://github.com/judaew/luacheck-action/releases/tag/v0.2.2